### PR TITLE
Fix acquisition of gpio port

### DIFF
--- a/src/lora_sx127x.erl
+++ b/src/lora_sx127x.erl
@@ -223,7 +223,7 @@ init_lora(SPI, Config) ->
 
     ok = set_mode(SPI, standby),
 
-    GPIO = gpio:open(),
+    GPIO = gpio:start(),
     ok = maybe_set_irq(SPI, GPIO, get_irq(Config)),
     ok = maybe_reset(GPIO, maps:get(reset, Config, undefined)).
 


### PR DESCRIPTION
Fixes a potential conflict if the gpio port driver is started before the lora driver for the sx127x module.

Closes #7